### PR TITLE
SSRF Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ lint:
 lint-install:
 	@if ! command -v golangci-lint >/dev/null 2>&1; then \
 		echo "Installing golangci-lint..."; \
-		go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
+		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1; \
 	fi
 	golangci-lint run --timeout=5m
 

--- a/scanner/certcheck.go
+++ b/scanner/certcheck.go
@@ -7,7 +7,9 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"strings"
 	"time"
@@ -20,6 +22,8 @@ const (
 	ocspExpired = "OCSP response has expired"
 	crlExpired  = "CRL has expired"
 )
+
+var lookupIPAddr = net.DefaultResolver.LookupIPAddr
 
 // CertStatus represents the validity status of a certificate.
 type CertStatus struct {
@@ -39,21 +43,110 @@ type CheckOptions struct {
 	Timeout           time.Duration
 }
 
-// httpGet performs a GET request with URL validation using provided context and client.
-func httpGet(ctx context.Context, client *http.Client, urlStr string) (*http.Response, error) {
-	// Parse and validate URL
+func validateOutboundURL(ctx context.Context, urlStr string) (*url.URL, error) {
 	parsedURL, err := url.Parse(urlStr)
 	if err != nil {
 		return nil, fmt.Errorf("invalid URL %q: %v", urlStr, err)
 	}
 
-	// Ensure scheme is http or https
 	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
 		return nil, fmt.Errorf("invalid URL scheme %q", parsedURL.Scheme)
 	}
 
-	if client == nil {
-		client = http.DefaultClient
+	if parsedURL.User != nil {
+		return nil, fmt.Errorf("URL user info is not allowed")
+	}
+
+	hostname := parsedURL.Hostname()
+	if hostname == "" {
+		return nil, fmt.Errorf("missing URL host")
+	}
+
+	ip, err := netip.ParseAddr(hostname)
+	if err == nil {
+		err = validateOutboundIP(ip.Unmap())
+		if err != nil {
+			return nil, err
+		}
+
+		return parsedURL, nil
+	}
+
+	err = validateResolvedHost(ctx, hostname)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsedURL, nil
+}
+
+func validateResolvedHost(ctx context.Context, hostname string) error {
+	resolvedIPs, err := lookupIPAddr(ctx, hostname)
+	if err != nil {
+		return fmt.Errorf("failed to resolve host %q: %v", hostname, err)
+	}
+
+	if len(resolvedIPs) == 0 {
+		return fmt.Errorf("host %q did not resolve to any address", hostname)
+	}
+
+	return validateResolvedIPs(resolvedIPs)
+}
+
+func validateResolvedIPs(resolvedIPs []net.IPAddr) error {
+	for _, resolvedIP := range resolvedIPs {
+		ip, err := netip.ParseAddr(resolvedIP.IP.String())
+		if err != nil {
+			return fmt.Errorf("failed to parse resolved IP %q: %v", resolvedIP.IP, err)
+		}
+
+		err = validateOutboundIP(ip.Unmap())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateOutboundIP(ip netip.Addr) error {
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() || ip.IsUnspecified() {
+		return fmt.Errorf("refusing to connect to non-public address %q", ip)
+	}
+
+	return nil
+}
+
+func safeHTTPClient(client *http.Client) *http.Client {
+	baseClient := client
+	if baseClient == nil {
+		baseClient = http.DefaultClient
+	}
+
+	safeClient := *baseClient
+	baseRedirect := baseClient.CheckRedirect
+	safeClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		_, err := validateOutboundURL(req.Context(), req.URL.String())
+		if err != nil {
+			return err
+		}
+
+		if baseRedirect != nil {
+			return baseRedirect(req, via)
+		}
+
+		return nil
+	}
+
+	return &safeClient
+}
+
+// httpGet performs a GET request with URL validation using provided context and client.
+func httpGet(ctx context.Context, client *http.Client, urlStr string) (*http.Response, error) {
+	parsedURL, err := validateOutboundURL(ctx, urlStr)
+	if err != nil {
+		return nil, err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)
@@ -61,7 +154,7 @@ func httpGet(ctx context.Context, client *http.Client, urlStr string) (*http.Res
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
 
-	return client.Do(req)
+	return safeHTTPClient(client).Do(req) // #nosec G704 URL is validated and restricted to public addresses above.
 }
 
 // httpPost performs a POST request with URL validation using provided context and client.
@@ -72,19 +165,9 @@ func httpPost(
 	contentType string,
 	body io.Reader,
 ) (*http.Response, error) {
-	// Parse and validate URL
-	parsedURL, err := url.Parse(urlStr)
+	parsedURL, err := validateOutboundURL(ctx, urlStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid URL %q: %v", urlStr, err)
-	}
-
-	// Ensure scheme is http or https
-	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return nil, fmt.Errorf("invalid URL scheme %q", parsedURL.Scheme)
-	}
-
-	if client == nil {
-		client = http.DefaultClient
+		return nil, err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, parsedURL.String(), body)
@@ -94,7 +177,7 @@ func httpPost(
 
 	req.Header.Set("Content-Type", contentType)
 
-	return client.Do(req)
+	return safeHTTPClient(client).Do(req) // #nosec G704 URL is validated and restricted to public addresses above.
 }
 
 // getIssuerCert retrieves the issuer certificate from the AIA extension.

--- a/scanner/certcheck_test.go
+++ b/scanner/certcheck_test.go
@@ -10,14 +10,29 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"golang.org/x/crypto/ocsp"
 )
+
+func TestMain(m *testing.M) {
+	originalLookup := lookupIPAddr
+	lookupIPAddr = func(ctx context.Context, host string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("93.184.216.34")}}, nil
+	}
+
+	exitCode := m.Run()
+	lookupIPAddr = originalLookup
+
+	os.Exit(exitCode)
+}
 
 func TestCheckCertStatus(t *testing.T) {
 	// Create a test issuer certificate and key
@@ -139,6 +154,14 @@ func TestCheckCertStatus(t *testing.T) {
 	}))
 	defer crlServer.Close()
 
+	client, publicURLs := newMappedTestClient(map[string]*httptest.Server{
+		"crl.example.test":          crlServer,
+		"issuer.example.test":       issuerServer,
+		"ocsp.example.test":         ocspServer,
+		"pem-issuer.example.test":   pemIssuerServer,
+		"wrong-issuer.example.test": wrongIssuerServer,
+	})
+
 	tests := []struct {
 		name           string
 		cert           *x509.Certificate
@@ -160,7 +183,7 @@ func TestCheckCertStatus(t *testing.T) {
 				},
 				NotBefore:             time.Now().Add(-48 * time.Hour),
 				NotAfter:              time.Now().Add(-24 * time.Hour),
-				IssuingCertificateURL: []string{issuerServer.URL},
+				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
 				AuthorityKeyId:        []byte{1, 2, 3},
 			},
 			wantValid:  false,
@@ -171,7 +194,7 @@ func TestCheckCertStatus(t *testing.T) {
 			cert: &x509.Certificate{
 				NotBefore:             time.Now().Add(24 * time.Hour),
 				NotAfter:              time.Now().Add(48 * time.Hour),
-				IssuingCertificateURL: []string{issuerServer.URL},
+				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
 			},
 			wantValid:  false,
 			wantErrors: []string{certNotYetValid},
@@ -202,7 +225,7 @@ func TestCheckCertStatus(t *testing.T) {
 			cert: &x509.Certificate{
 				NotBefore:             time.Now().Add(-24 * time.Hour),
 				NotAfter:              time.Now().Add(24 * time.Hour),
-				IssuingCertificateURL: []string{issuerServer.URL},
+				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
 				AuthorityKeyId:        []byte{1, 2, 3},
 			},
 			wantValid:      true,
@@ -221,9 +244,9 @@ func TestCheckCertStatus(t *testing.T) {
 				},
 				NotBefore:             time.Now().Add(-24 * time.Hour),
 				NotAfter:              time.Now().Add(24 * time.Hour),
-				IssuingCertificateURL: []string{issuerServer.URL},
+				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
 				AuthorityKeyId:        []byte{1, 2, 3},
-				OCSPServer:            []string{ocspServer.URL},
+				OCSPServer:            []string{publicURLs["ocsp.example.test"]},
 			},
 			wantValid:      true,
 			wantOCSPStatus: "Good",
@@ -234,9 +257,9 @@ func TestCheckCertStatus(t *testing.T) {
 			cert: &x509.Certificate{
 				NotBefore:             time.Now().Add(-24 * time.Hour),
 				NotAfter:              time.Now().Add(24 * time.Hour),
-				IssuingCertificateURL: []string{issuerServer.URL},
+				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
 				AuthorityKeyId:        []byte{1, 2, 3},
-				CRLDistributionPoints: []string{crlServer.URL},
+				CRLDistributionPoints: []string{publicURLs["crl.example.test"]},
 			},
 			wantValid:      true,
 			wantOCSPStatus: certValidNoOCSP,
@@ -247,7 +270,7 @@ func TestCheckCertStatus(t *testing.T) {
 			cert: &x509.Certificate{
 				NotBefore:             time.Now().Add(-24 * time.Hour),
 				NotAfter:              time.Now().Add(24 * time.Hour),
-				IssuingCertificateURL: []string{issuerServer.URL},
+				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
 				AuthorityKeyId:        []byte{1, 2, 3},
 				CRLDistributionPoints: []string{"ldap://example.com/cn=crl"},
 			},
@@ -260,7 +283,7 @@ func TestCheckCertStatus(t *testing.T) {
 			cert: &x509.Certificate{
 				NotBefore:             time.Now().Add(-24 * time.Hour),
 				NotAfter:              time.Now().Add(24 * time.Hour),
-				IssuingCertificateURL: []string{issuerServer.URL},
+				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
 				AuthorityKeyId:        []byte{1, 2, 3},
 				OCSPServer:            []string{"http://invalid.example.com"},
 			},
@@ -276,7 +299,7 @@ func TestCheckCertStatus(t *testing.T) {
 			cert: &x509.Certificate{
 				NotBefore:             time.Now().Add(-24 * time.Hour),
 				NotAfter:              time.Now().Add(24 * time.Hour),
-				IssuingCertificateURL: []string{issuerServer.URL},
+				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
 				AuthorityKeyId:        []byte{1, 2, 3},
 				CRLDistributionPoints: []string{"http://invalid.example.com"},
 			},
@@ -289,7 +312,7 @@ func TestCheckCertStatus(t *testing.T) {
 			cert: &x509.Certificate{
 				NotBefore:             time.Now().Add(-24 * time.Hour),
 				NotAfter:              time.Now().Add(24 * time.Hour),
-				IssuingCertificateURL: []string{pemIssuerServer.URL},
+				IssuingCertificateURL: []string{publicURLs["pem-issuer.example.test"]},
 				AuthorityKeyId:        []byte{1, 2, 3},
 			},
 			wantValid:      true,
@@ -301,7 +324,7 @@ func TestCheckCertStatus(t *testing.T) {
 			cert: &x509.Certificate{
 				NotBefore:             time.Now().Add(-24 * time.Hour),
 				NotAfter:              time.Now().Add(24 * time.Hour),
-				IssuingCertificateURL: []string{wrongIssuerServer.URL},
+				IssuingCertificateURL: []string{publicURLs["wrong-issuer.example.test"]},
 				AuthorityKeyId:        []byte{1, 2, 3},
 			},
 			wantValid:      false,
@@ -316,7 +339,7 @@ func TestCheckCertStatus(t *testing.T) {
 			status := CheckCertStatus(
 				context.Background(),
 				tt.cert,
-				CheckOptions{IncludeStatusData: false, HTTPClient: http.DefaultClient},
+				CheckOptions{IncludeStatusData: false, HTTPClient: client},
 			)
 			if status.IsValid != tt.wantValid {
 				t.Errorf("CheckCertStatus().IsValid = %v, want %v", status.IsValid, tt.wantValid)
@@ -364,7 +387,7 @@ func TestCheckCertStatus(t *testing.T) {
 				statusWith := CheckCertStatus(
 					context.Background(),
 					tt.cert,
-					CheckOptions{IncludeStatusData: true, HTTPClient: http.DefaultClient},
+					CheckOptions{IncludeStatusData: true, HTTPClient: client},
 				)
 				// Only expect OCSPResponse if the status indicates we received a response
 				if statusWith.OCSPStatus != "" {
@@ -379,7 +402,7 @@ func TestCheckCertStatus(t *testing.T) {
 				statusWith := CheckCertStatus(
 					context.Background(),
 					tt.cert,
-					CheckOptions{IncludeStatusData: true, HTTPClient: http.DefaultClient},
+					CheckOptions{IncludeStatusData: true, HTTPClient: client},
 				)
 				// Only expect CRLData when we actually fetched a CRL (status Good or Revoked)
 				if strings.HasPrefix(statusWith.CRLStatus, "Good") || strings.HasPrefix(statusWith.CRLStatus, "Revoked") {
@@ -429,10 +452,14 @@ func TestCheckCertStatus_CustomHTTPClient(t *testing.T) {
 	}))
 	defer issuerServer.Close()
 
+	routedClient, publicURLs := newMappedTestClient(map[string]*httptest.Server{
+		"issuer.example.test": issuerServer,
+	})
+
 	// Create a custom HTTP client with a transport that tracks requests
 	requestCount := 0
 	customTransport := &testTransport{
-		inner: http.DefaultTransport,
+		inner: routedClient.Transport,
 		onRequest: func(req *http.Request) {
 			requestCount++
 		},
@@ -450,7 +477,7 @@ func TestCheckCertStatus_CustomHTTPClient(t *testing.T) {
 		},
 		NotBefore:             time.Now().Add(-24 * time.Hour),
 		NotAfter:              time.Now().Add(24 * time.Hour),
-		IssuingCertificateURL: []string{issuerServer.URL},
+		IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
 		AuthorityKeyId:        []byte{1, 2, 3},
 	}
 
@@ -509,6 +536,10 @@ func TestCheckCertStatus_Timeout(t *testing.T) {
 	}))
 	defer slowServer.Close()
 
+	client, publicURLs := newMappedTestClient(map[string]*httptest.Server{
+		"slow-issuer.example.test": slowServer,
+	})
+
 	// Create a test certificate that requires AIA fetch
 	cert := &x509.Certificate{
 		SerialNumber: big.NewInt(100),
@@ -520,7 +551,7 @@ func TestCheckCertStatus_Timeout(t *testing.T) {
 		},
 		NotBefore:             time.Now().Add(-24 * time.Hour),
 		NotAfter:              time.Now().Add(24 * time.Hour),
-		IssuingCertificateURL: []string{slowServer.URL},
+		IssuingCertificateURL: []string{publicURLs["slow-issuer.example.test"]},
 		AuthorityKeyId:        []byte{1, 2, 3},
 	}
 
@@ -528,7 +559,7 @@ func TestCheckCertStatus_Timeout(t *testing.T) {
 	status := CheckCertStatus(
 		context.Background(),
 		cert,
-		CheckOptions{IncludeStatusData: false, HTTPClient: http.DefaultClient, Timeout: 10 * time.Millisecond},
+		CheckOptions{IncludeStatusData: false, HTTPClient: client, Timeout: 10 * time.Millisecond},
 	)
 
 	// Verify that the call timed out and certificate is invalid due to unreachable issuer
@@ -625,11 +656,14 @@ func TestFetchCRL_PEM(t *testing.T) {
 	}))
 	defer crlServer.Close()
 
+	client, publicURLs := newMappedTestClient(map[string]*httptest.Server{
+		"crl.example.test": crlServer,
+	})
+
 	// Call fetchCRL
 	ctx := context.Background()
-	client := &http.Client{}
 
-	crl, err := fetchCRL(ctx, client, crlServer.URL)
+	crl, err := fetchCRL(ctx, client, publicURLs["crl.example.test"])
 	if err != nil {
 		t.Fatalf("fetchCRL failed: %v", err)
 	}
@@ -638,4 +672,78 @@ func TestFetchCRL_PEM(t *testing.T) {
 	if crl.Number.Cmp(big.NewInt(1)) != 0 {
 		t.Errorf("Expected CRL number 1, got %s", crl.Number.String())
 	}
+}
+
+func TestCheckCertStatus_BlocksPrivateIssuerAddress(t *testing.T) {
+	originalLookup := lookupIPAddr
+	lookupIPAddr = func(ctx context.Context, host string) ([]net.IPAddr, error) {
+		if host == "issuer.example.test" {
+			return []net.IPAddr{{IP: net.IP{127, 0, 0, 1}}}, nil
+		}
+
+		return originalLookup(ctx, host)
+	}
+
+	defer func() {
+		lookupIPAddr = originalLookup
+	}()
+
+	cert := &x509.Certificate{
+		NotBefore:             time.Now().Add(-24 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IssuingCertificateURL: []string{"http://issuer.example.test/issuer.der"},
+	}
+
+	status := CheckCertStatus(context.Background(), cert, CheckOptions{})
+	if status.IsValid {
+		t.Fatal("expected certificate to be invalid when issuer URL resolves to loopback")
+	}
+
+	found := false
+
+	for _, err := range status.Errors {
+		if strings.Contains(err, "refusing to connect to non-public address") {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected SSRF protection error, got %v", status.Errors)
+	}
+}
+
+func newMappedTestClient(servers map[string]*httptest.Server) (*http.Client, map[string]string) {
+	hostToAddr := make(map[string]string, len(servers))
+	publicURLs := make(map[string]string, len(servers))
+
+	for host, server := range servers {
+		serverURL, err := url.Parse(server.URL)
+		if err != nil {
+			panic(err)
+		}
+
+		hostToAddr[host] = serverURL.Host
+		serverURL.Host = host
+		publicURLs[host] = serverURL.String()
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, _, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+
+		if mappedAddr, ok := hostToAddr[host]; ok {
+			addr = mappedAddr
+		} else if strings.HasSuffix(host, ".example.test") || strings.HasSuffix(host, ".example.com") {
+			return nil, fmt.Errorf("no mapped test server for host %q", host)
+		}
+
+		return (&net.Dialer{}).DialContext(ctx, network, addr)
+	}
+
+	return &http.Client{Transport: transport}, publicURLs
 }


### PR DESCRIPTION
This pull request significantly improves the security and robustness of certificate status checking by adding protections against SSRF (Server-Side Request Forgery) attacks and enhancing test coverage. The primary changes are the introduction of strict outbound URL and IP address validation, ensuring that HTTP requests for certificate validation cannot be made to private or non-public addresses. The tests are updated and expanded to verify these protections and to ensure correct network routing in the test environment.

Key security enhancements:

* Added strict validation of outbound URLs and resolved IP addresses in `certcheck.go`, blocking requests to loopback, private, link-local, multicast, and unspecified addresses to prevent SSRF vulnerabilities. This includes new helper functions like `validateOutboundURL`, `validateResolvedHost`, and `validateOutboundIP`. (`[[1]](diffhunk://#diff-4cf9575550d76331998240b0ada3800e09707d7422d2191a089be79558169ae9L42-R157)`, `[[2]](diffhunk://#diff-4cf9575550d76331998240b0ada3800e09707d7422d2191a089be79558169ae9R26-R27)`)
* Modified HTTP clients to enforce this validation on redirects as well, by wrapping the client's `CheckRedirect` handler. (`[scanner/certcheck.goL42-R157](diffhunk://#diff-4cf9575550d76331998240b0ada3800e09707d7422d2191a089be79558169ae9L42-R157)`)

Test suite improvements:

* Refactored tests in `certcheck_test.go` to use a new `newMappedTestClient` helper, which maps test hostnames to their respective test servers, ensuring that network requests during tests are routed correctly and SSRF protections are exercised. (`[[1]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747R157-R164)`, `[[2]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747R455-R462)`, `[[3]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747R539-R542)`, `[[4]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747R659-R666)`)
* Added a new test `TestCheckCertStatus_BlocksPrivateIssuerAddress` to explicitly verify that the SSRF protections block certificate issuer URLs resolving to loopback addresses. (`[scanner/certcheck_test.goR676-R749](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747R676-R749)`)

Dependency and tooling update:

* Updated the `Makefile` to pin `golangci-lint` to version `v2.10.1` for consistent linting results. (`[MakefileL22-R22](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L22-R22)`)

These changes collectively harden the certificate scanning logic against network-based attacks and ensure that the codebase is well-tested for these scenarios.