### PR TITLE
Update Dependabot configuration and workflow versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,16 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      all:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
   lint:
     permissions:
       contents: read
-    uses: jsandas/github-actions/.github/workflows/golang-lint.yml@main
+    uses: jsandas/github-actions/.github/workflows/golang-lint.yml@13150b57906d67e1731f602c2b78a5d13b13b1bc
 
   security:
     permissions:
       contents: read
       security-events: write
-    uses: jsandas/github-actions/.github/workflows/golang-security.yml@main
+    uses: jsandas/github-actions/.github/workflows/golang-security.yml@13150b57906d67e1731f602c2b78a5d13b13b1bc
 
   test:
     name: Unit Tests
@@ -28,19 +28,19 @@ jobs:
     needs: [lint]
     
     steps:
-    - uses: actions/checkout@v6.0.2
-      
-    - uses: actions/setup-go@v6.4.0
-      with:
-        go-version-file: "go.mod"
-        cache: true
+      - uses: actions/checkout@v6.0.2
+        
+      - uses: actions/setup-go@v6.4.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
 
-    - name: Run unit tests
-      run: go test -v ./... -coverprofile=coverage.out
+      - name: Run unit tests
+        run: go test -v ./... -coverprofile=coverage.out
 
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v6.0.0
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./coverage.out
-        fail_ci_if_error: false
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.out
+          fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
     needs: [lint]
     
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v6.0.2
       
-    - uses: actions/setup-go@v6
+    - uses: actions/setup-go@v6.4.0
       with:
         go-version-file: "go.mod"
         cache: true
@@ -39,7 +39,7 @@ jobs:
       run: go test -v ./... -coverprofile=coverage.out
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.out


### PR DESCRIPTION
This pull request updates the repository's dependency management and CI workflow configuration for improved reliability and maintainability. The main changes are to Dependabot's update schedule and grouping, and to the GitHub Actions workflow, which now uses pinned and updated action versions.

Dependency management improvements:

* Changed Dependabot update interval from weekly to monthly for both `gomod` and `github-actions`, and added grouping so all updates are batched together. (.github/dependabot.yml)

CI workflow enhancements:

* Pinned the `golang-lint` and `golang-security` workflow actions to a specific commit SHA for improved reproducibility and security. (.github/workflows/ci.yml)
* Updated `actions/checkout` to version `v6.0.2` and `actions/setup-go` to version `v6.4.0` for the test job. (.github/workflows/ci.yml)
* Updated `codecov/codecov-action` to version `v6.0.0` for uploading coverage reports. (.github/workflows/ci.yml)