### PR TITLE
Golanglint fixes

### DIFF
--- a/scanner/certcheck.go
+++ b/scanner/certcheck.go
@@ -19,8 +19,11 @@ import (
 
 // Additional certificate validation error constants.
 const (
-	ocspExpired = "OCSP response has expired"
-	crlExpired  = "CRL has expired"
+	ocspExpired       = "OCSP response has expired"
+	crlExpired        = "CRL has expired"
+	ocspStatusUnknown = "Unknown"
+	ocspStatusGood    = "Good"
+	crlStatusGood     = "Good"
 )
 
 var lookupIPAddr = net.DefaultResolver.LookupIPAddr
@@ -294,12 +297,12 @@ func processOCSPResponse(response *ocsp.Response, status *CertStatus, includeSta
 
 	switch response.Status {
 	case ocsp.Good:
-		status.OCSPStatus = "Good"
+		status.OCSPStatus = ocspStatusGood
 	case ocsp.Revoked:
 		status.OCSPStatus = fmt.Sprintf("Revoked at %s", response.RevokedAt)
 		status.IsValid = false
 	case ocsp.Unknown:
-		status.OCSPStatus = "Unknown"
+		status.OCSPStatus = ocspStatusUnknown
 	}
 }
 
@@ -415,7 +418,7 @@ func updateCRLStatus(cert *x509.Certificate, crl *x509.RevocationList, status *C
 		}
 	}
 
-	status.CRLStatus = "Good"
+	status.CRLStatus = crlStatusGood
 
 	return false
 }

--- a/scanner/certcheck_test.go
+++ b/scanner/certcheck_test.go
@@ -22,6 +22,12 @@ import (
 	"golang.org/x/crypto/ocsp"
 )
 
+const (
+	issuerCommonName = "issuer.example.test"
+	ocspCommonName   = "ocsp.example.test"
+	aiaUrl           = "http://invalid.example.com"
+)
+
 var testCertSubject = pkix.Name{
 	CommonName:         "Test Server",
 	Country:            []string{"US"},
@@ -158,8 +164,8 @@ func TestCheckCertStatus(t *testing.T) {
 
 	client, publicURLs := newMappedTestClient(map[string]*httptest.Server{
 		"crl.example.test":          crlServer,
-		"issuer.example.test":       issuerServer,
-		"ocsp.example.test":         ocspServer,
+		issuerCommonName:            issuerServer,
+		ocspCommonName:              ocspServer,
 		"pem-issuer.example.test":   pemIssuerServer,
 		"wrong-issuer.example.test": wrongIssuerServer,
 	})
@@ -180,7 +186,7 @@ func TestCheckCertStatus(t *testing.T) {
 				Subject:               testCertSubject,
 				NotBefore:             time.Now().Add(-48 * time.Hour),
 				NotAfter:              time.Now().Add(-24 * time.Hour),
-				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
+				IssuingCertificateURL: []string{publicURLs[issuerCommonName]},
 				AuthorityKeyId:        []byte{1, 2, 3},
 			},
 			wantValid:  false,
@@ -191,7 +197,7 @@ func TestCheckCertStatus(t *testing.T) {
 			cert: &x509.Certificate{
 				NotBefore:             time.Now().Add(24 * time.Hour),
 				NotAfter:              time.Now().Add(48 * time.Hour),
-				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
+				IssuingCertificateURL: []string{publicURLs[issuerCommonName]},
 			},
 			wantValid:  false,
 			wantErrors: []string{certNotYetValid},
@@ -211,7 +217,7 @@ func TestCheckCertStatus(t *testing.T) {
 			cert: &x509.Certificate{
 				NotBefore:             time.Now().Add(-24 * time.Hour),
 				NotAfter:              time.Now().Add(24 * time.Hour),
-				IssuingCertificateURL: []string{"http://invalid.example.com"},
+				IssuingCertificateURL: []string{aiaUrl},
 			},
 			wantValid:     false,
 			wantErrors:    []string{certUnreachable},
@@ -222,7 +228,7 @@ func TestCheckCertStatus(t *testing.T) {
 			cert: &x509.Certificate{
 				NotBefore:             time.Now().Add(-24 * time.Hour),
 				NotAfter:              time.Now().Add(24 * time.Hour),
-				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
+				IssuingCertificateURL: []string{publicURLs[issuerCommonName]},
 				AuthorityKeyId:        []byte{1, 2, 3},
 			},
 			wantValid:      true,
@@ -236,9 +242,9 @@ func TestCheckCertStatus(t *testing.T) {
 				Subject:               testCertSubject,
 				NotBefore:             time.Now().Add(-24 * time.Hour),
 				NotAfter:              time.Now().Add(24 * time.Hour),
-				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
+				IssuingCertificateURL: []string{publicURLs[issuerCommonName]},
 				AuthorityKeyId:        []byte{1, 2, 3},
-				OCSPServer:            []string{publicURLs["ocsp.example.test"]},
+				OCSPServer:            []string{publicURLs[ocspCommonName]},
 			},
 			wantValid:      true,
 			wantOCSPStatus: "Good",
@@ -249,7 +255,7 @@ func TestCheckCertStatus(t *testing.T) {
 			cert: &x509.Certificate{
 				NotBefore:             time.Now().Add(-24 * time.Hour),
 				NotAfter:              time.Now().Add(24 * time.Hour),
-				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
+				IssuingCertificateURL: []string{publicURLs[issuerCommonName]},
 				AuthorityKeyId:        []byte{1, 2, 3},
 				CRLDistributionPoints: []string{publicURLs["crl.example.test"]},
 			},
@@ -262,7 +268,7 @@ func TestCheckCertStatus(t *testing.T) {
 			cert: &x509.Certificate{
 				NotBefore:             time.Now().Add(-24 * time.Hour),
 				NotAfter:              time.Now().Add(24 * time.Hour),
-				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
+				IssuingCertificateURL: []string{publicURLs[issuerCommonName]},
 				AuthorityKeyId:        []byte{1, 2, 3},
 				CRLDistributionPoints: []string{"ldap://example.com/cn=crl"},
 			},
@@ -275,9 +281,9 @@ func TestCheckCertStatus(t *testing.T) {
 			cert: &x509.Certificate{
 				NotBefore:             time.Now().Add(-24 * time.Hour),
 				NotAfter:              time.Now().Add(24 * time.Hour),
-				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
+				IssuingCertificateURL: []string{publicURLs[issuerCommonName]},
 				AuthorityKeyId:        []byte{1, 2, 3},
-				OCSPServer:            []string{"http://invalid.example.com"},
+				OCSPServer:            []string{aiaUrl},
 			},
 			wantValid: true,
 			wantErrors: []string{
@@ -291,9 +297,9 @@ func TestCheckCertStatus(t *testing.T) {
 			cert: &x509.Certificate{
 				NotBefore:             time.Now().Add(-24 * time.Hour),
 				NotAfter:              time.Now().Add(24 * time.Hour),
-				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
+				IssuingCertificateURL: []string{publicURLs[issuerCommonName]},
 				AuthorityKeyId:        []byte{1, 2, 3},
-				CRLDistributionPoints: []string{"http://invalid.example.com"},
+				CRLDistributionPoints: []string{aiaUrl},
 			},
 			wantValid:      true,
 			wantErrors:     []string{certUnreachableCRL},

--- a/scanner/certcheck_test.go
+++ b/scanner/certcheck_test.go
@@ -22,6 +22,13 @@ import (
 	"golang.org/x/crypto/ocsp"
 )
 
+var testCertSubject = pkix.Name{
+	CommonName:         "Test Server",
+	Country:            []string{"US"},
+	Organization:       []string{"Test Org"},
+	OrganizationalUnit: []string{"Test Unit"},
+}
+
 func TestMain(m *testing.M) {
 	originalLookup := lookupIPAddr
 	lookupIPAddr = func(ctx context.Context, host string) ([]net.IPAddr, error) {
@@ -42,13 +49,8 @@ func TestCheckCertStatus(t *testing.T) {
 	}
 
 	issuerTemplate := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject: pkix.Name{
-			CommonName:         "Test Issuer CA",
-			Country:            []string{"US"},
-			Organization:       []string{"Test Org"},
-			OrganizationalUnit: []string{"Test Unit"},
-		},
+		SerialNumber:          big.NewInt(1),
+		Subject:               testCertSubject,
 		NotBefore:             time.Now().Add(-24 * time.Hour),
 		NotAfter:              time.Now().Add(24 * time.Hour),
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
@@ -174,13 +176,8 @@ func TestCheckCertStatus(t *testing.T) {
 		{
 			name: certExpired,
 			cert: &x509.Certificate{
-				SerialNumber: big.NewInt(100),
-				Subject: pkix.Name{
-					CommonName:         "Test Server",
-					Country:            []string{"US"},
-					Organization:       []string{"Test Org"},
-					OrganizationalUnit: []string{"Test Unit"},
-				},
+				SerialNumber:          big.NewInt(100),
+				Subject:               testCertSubject,
 				NotBefore:             time.Now().Add(-48 * time.Hour),
 				NotAfter:              time.Now().Add(-24 * time.Hour),
 				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
@@ -235,13 +232,8 @@ func TestCheckCertStatus(t *testing.T) {
 		{
 			name: certValidWithOCSP,
 			cert: &x509.Certificate{
-				SerialNumber: big.NewInt(100),
-				Subject: pkix.Name{
-					CommonName:         "Test Server",
-					Country:            []string{"US"},
-					Organization:       []string{"Test Org"},
-					OrganizationalUnit: []string{"Test Unit"},
-				},
+				SerialNumber:          big.NewInt(100),
+				Subject:               testCertSubject,
 				NotBefore:             time.Now().Add(-24 * time.Hour),
 				NotAfter:              time.Now().Add(24 * time.Hour),
 				IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
@@ -424,13 +416,8 @@ func TestCheckCertStatus_CustomHTTPClient(t *testing.T) {
 	}
 
 	issuerTemplate := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject: pkix.Name{
-			CommonName:         "Test Issuer CA",
-			Country:            []string{"US"},
-			Organization:       []string{"Test Org"},
-			OrganizationalUnit: []string{"Test Unit"},
-		},
+		SerialNumber:          big.NewInt(1),
+		Subject:               testCertSubject,
 		NotBefore:             time.Now().Add(-24 * time.Hour),
 		NotAfter:              time.Now().Add(24 * time.Hour),
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
@@ -468,13 +455,8 @@ func TestCheckCertStatus_CustomHTTPClient(t *testing.T) {
 
 	// Create a test certificate that requires AIA fetch
 	cert := &x509.Certificate{
-		SerialNumber: big.NewInt(100),
-		Subject: pkix.Name{
-			CommonName:         "Test Server",
-			Country:            []string{"US"},
-			Organization:       []string{"Test Org"},
-			OrganizationalUnit: []string{"Test Unit"},
-		},
+		SerialNumber:          big.NewInt(100),
+		Subject:               testCertSubject,
 		NotBefore:             time.Now().Add(-24 * time.Hour),
 		NotAfter:              time.Now().Add(24 * time.Hour),
 		IssuingCertificateURL: []string{publicURLs["issuer.example.test"]},
@@ -507,13 +489,8 @@ func TestCheckCertStatus_Timeout(t *testing.T) {
 	}
 
 	issuerTemplate := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject: pkix.Name{
-			CommonName:         "Test Issuer CA",
-			Country:            []string{"US"},
-			Organization:       []string{"Test Org"},
-			OrganizationalUnit: []string{"Test Unit"},
-		},
+		SerialNumber:          big.NewInt(1),
+		Subject:               testCertSubject,
 		NotBefore:             time.Now().Add(-24 * time.Hour),
 		NotAfter:              time.Now().Add(24 * time.Hour),
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
@@ -542,13 +519,8 @@ func TestCheckCertStatus_Timeout(t *testing.T) {
 
 	// Create a test certificate that requires AIA fetch
 	cert := &x509.Certificate{
-		SerialNumber: big.NewInt(100),
-		Subject: pkix.Name{
-			CommonName:         "Test Server",
-			Country:            []string{"US"},
-			Organization:       []string{"Test Org"},
-			OrganizationalUnit: []string{"Test Unit"},
-		},
+		SerialNumber:          big.NewInt(100),
+		Subject:               testCertSubject,
 		NotBefore:             time.Now().Add(-24 * time.Hour),
 		NotAfter:              time.Now().Add(24 * time.Hour),
 		IssuingCertificateURL: []string{publicURLs["slow-issuer.example.test"]},
@@ -604,13 +576,8 @@ func TestFetchCRL_PEM(t *testing.T) {
 	}
 
 	issuerTemplate := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject: pkix.Name{
-			CommonName:         "Test Issuer CA",
-			Country:            []string{"US"},
-			Organization:       []string{"Test Org"},
-			OrganizationalUnit: []string{"Test Unit"},
-		},
+		SerialNumber:          big.NewInt(1),
+		Subject:               testCertSubject,
 		NotBefore:             time.Now().Add(-24 * time.Hour),
 		NotAfter:              time.Now().Add(24 * time.Hour),
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,


### PR DESCRIPTION
This pull request makes several improvements to both the main certificate checking logic and its associated tests. The key changes are the introduction of named constants for commonly used status strings in `certcheck.go` and the refactoring of test code in `certcheck_test.go` to use shared variables and constants for repeated values. This enhances code maintainability, reduces duplication, and improves clarity.

**Improvements to status handling in certificate checking:**

* Added named constants for OCSP and CRL status strings (`ocspStatusUnknown`, `ocspStatusGood`, `crlStatusGood`) and updated the code to use these constants instead of hardcoded strings. [[1]](diffhunk://#diff-4cf9575550d76331998240b0ada3800e09707d7422d2191a089be79558169ae9R24-R26) [[2]](diffhunk://#diff-4cf9575550d76331998240b0ada3800e09707d7422d2191a089be79558169ae9L297-R305) [[3]](diffhunk://#diff-4cf9575550d76331998240b0ada3800e09707d7422d2191a089be79558169ae9L418-R421)

**Refactoring and simplification of test code:**

* Introduced shared constants (`issuerCommonName`, `ocspCommonName`, `aiaUrl`) and a reusable `testCertSubject` for certificate subject fields in `certcheck_test.go`, replacing repeated literal values throughout the tests.
* Updated all test cases in `certcheck_test.go` to use the new shared constants and variables, reducing duplication and making the tests easier to maintain. [[1]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747L46-R59) [[2]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747L159-R168) [[3]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747L178-R189) [[4]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747L197-R200) [[5]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747L217-R220) [[6]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747L228-R231) [[7]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747L239-R247) [[8]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747L260-R258) [[9]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747L273-R271) [[10]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747L286-R286) [[11]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747L302-R302) [[12]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747L428-R426) [[13]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747L472-R465) [[14]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747L511-R499) [[15]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747L546-R529) [[16]](diffhunk://#diff-195e0fe8fd9d0826695d20a33cd61c9310801cc24b94d0da1743ac2e0ffbc747L608-R586)